### PR TITLE
add enabling legislation atoz

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     bindex (0.8.1)
     bootsnap (1.18.6)
       msgpack (~> 1.2)
@@ -91,7 +91,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
+    connection_pool (2.5.4)
     crass (1.0.6)
     csv (3.3.5)
     date (3.4.1)
@@ -129,7 +129,7 @@ GEM
     mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
-    net-imap (0.5.9)
+    net-imap (0.5.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -159,10 +159,10 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (6.6.1)
+    puma (7.0.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.0)
+    rack (3.2.1)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -206,7 +206,7 @@ GEM
     regexp_parser (2.11.2)
     reline (0.6.2)
       io-console (~> 0.5)
-    rexml (3.4.1)
+    rexml (3.4.2)
     rollbar (3.6.2)
     rspec-core (3.13.5)
       rspec-support (~> 3.13.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -395,6 +395,114 @@ body.subsection-notes .subnav a.notes {
 	border-bottom-color: #006e45;
 	color: #4d4d4d;
 }
+body.subsection-all .subnav a.all {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-a .subnav a.a {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-b .subnav a.b {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-c .subnav a.c {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-d .subnav a.d {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-e .subnav a.e {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-f .subnav a.f {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-g .subnav a.g {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-h .subnav a.h {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-i .subnav a.i {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-j .subnav a.j {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-k .subnav a.k {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-l .subnav a.l {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-m .subnav a.m {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-n .subnav a.n {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-o .subnav a.o {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-p .subnav a.p {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-q .subnav a.q {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-r .subnav a.r {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-s .subnav a.s {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-t .subnav a.t {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-u .subnav a.u {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-v .subnav a.v {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-w .subnav a.w {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-x .subnav a.x {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-y .subnav a.y {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
+body.subsection-z .subnav a.z {
+	border-bottom-color: #006e45;
+	color: #4d4d4d;
+}
 
 a {
   overflow-wrap: break-word;

--- a/app/controllers/enabling_legislation_ato_z_controller.rb
+++ b/app/controllers/enabling_legislation_ato_z_controller.rb
@@ -1,0 +1,41 @@
+class EnablingLegislationAtoZController < ApplicationController
+
+  # We include modules required to get an a to z of enabling legislation and enabling legislation starting with a letter.
+  include Sparql::Get::EnablingLegislationAtoz
+  include Sparql::Queries::EnablingLegislationAtoz
+  include Sparql::Get::EnablingLegislationAtozLetter
+  include Sparql::Queries::EnablingLegislationAtozLetter
+  include Sparql::Get::Response
+
+  def index
+    
+    # We get the enabling legislation a to z.
+    @letters = get_enabling_legislation_atoz
+    
+    @page_title = 'Enabling legislation - A to Z'
+    @multiline_page_title = "Enabling legislation <span class='subhead'>A to Z</span>".html_safe
+    @description = 'A to Z of legislation delegating powers, enabling one or more instruments subject to parliamentary procedure.'
+    @crumb << { label: 'Enabling legislation', url: enabling_legislation_list_url }
+    @crumb << { label: 'A to Z', url: nil }
+    @section = 'enabling-legislation'
+  end
+  
+  def show
+    letter = params[:letter]
+    
+    # We get the enabling legislation a to z.
+    @letters = get_enabling_legislation_atoz
+    
+    # We get the enabling legislation items starting with that letter.
+    @enabling_legislations = get_enabling_legislation_atoz_letter( letter )
+    
+    @page_title = "Enabling legislation - #{letter}"
+    @multiline_page_title = "Enabling legislation <span class='subhead'>#{letter.upcase}</span>".html_safe
+    @description = "Legislation delegating powers, enabling one or more instruments subject to parliamentary procedure, starting with #{letter.upcase}."
+    @crumb << { label: 'Enabling legislation', url: enabling_legislation_list_url }
+    @crumb << { label: 'A to Z', url: enabling_legislation_atoz_list_url }
+    @crumb << { label: letter.upcase, url: nil }
+    @section = 'enabling-legislation'
+    @subsection = letter
+  end
+end

--- a/app/controllers/enabling_legislation_controller.rb
+++ b/app/controllers/enabling_legislation_controller.rb
@@ -1,6 +1,8 @@
 class EnablingLegislationController < ApplicationController
 
   # We include modules required to get all work packages and a work package.
+  include Sparql::Get::EnablingLegislationAtoz
+  include Sparql::Queries::EnablingLegislationAtoz
   include Sparql::Get::EnablingLegislations
   include Sparql::Queries::EnablingLegislations
   include Sparql::Get::EnablingLegislation
@@ -13,13 +15,18 @@ class EnablingLegislationController < ApplicationController
 
   def index
     
+    # We get the enabling legislation a to z.
+    @letters = get_enabling_legislation_atoz
+    
     # We get the enabling legislation items.
     @enabling_legislations = get_enabling_legislations
     
     @page_title = 'Enabling legislation'
+    @multiline_page_title = "Enabling legislation <span class='subhead'>All</span>".html_safe
     @description = 'Legislation delegating powers, enabling one or more instruments subject to parliamentary procedure.'
     @crumb << { label: 'Enabling legislation', url: nil }
     @section = 'enabling-legislation'
+    @subsection = 'all'
   end
 
   def show

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -1,0 +1,5 @@
+class Letter
+  
+  attr_accessor :letter
+  attr_accessor :count
+end

--- a/app/views/enabling_legislation/_list_intro.html.erb
+++ b/app/views/enabling_legislation/_list_intro.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag( 'p', 'Legislation delegating powers, enabling one or more instruments subject to parliamentary procedure.' ) %>
+
+<%= render :partial => 'enabling_legislation_ato_z/nav', :object => @letters %>

--- a/app/views/enabling_legislation/index.html.erb
+++ b/app/views/enabling_legislation/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag( 'p', 'Legislation delegating powers, enabling one or more instruments subject to parliamentary procedure.' ) %>
+<%= render :partial => 'list_intro' %>
 
 <%= list_item_count_sentence( 'enabling legislation item', @enabling_legislations.size ) %>
 

--- a/app/views/enabling_legislation_ato_z/_letter.html.erb
+++ b/app/views/enabling_legislation_ato_z/_letter.html.erb
@@ -1,0 +1,1 @@
+<%= link_to( letter.letter, enabling_legislation_atoz_show_url( :letter => letter.letter.downcase ), :class => letter.letter.downcase ) %>

--- a/app/views/enabling_legislation_ato_z/_nav.html.erb
+++ b/app/views/enabling_legislation_ato_z/_nav.html.erb
@@ -1,0 +1,4 @@
+<p class="subnav">
+	<%= render :partial => 'enabling_legislation_ato_z/letter', :collection => nav %>
+	<%= link_to( 'All', enabling_legislation_list_url, :class => 'all' ) %>
+</p>

--- a/app/views/enabling_legislation_ato_z/index.html.erb
+++ b/app/views/enabling_legislation_ato_z/index.html.erb
@@ -1,0 +1,1 @@
+<%= render :partial => 'enabling_legislation/list_intro' %>

--- a/app/views/enabling_legislation_ato_z/show.html.erb
+++ b/app/views/enabling_legislation_ato_z/show.html.erb
@@ -1,0 +1,7 @@
+<%= render :partial => 'enabling_legislation/list_intro' %>
+
+<%= list_item_count_sentence( 'enabling legislation item', @enabling_legislations.size ) %>
+
+<ol>
+	<%= render :partial => 'enabling_legislation/enabling_legislation', :collection => @enabling_legislations %>
+</ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,9 @@ Rails.application.routes.draw do
   
   get 'procedure-browser/work-packageable-things/:work_packageable_thing/following' => 'work_packageable_thing_following#index', as: :work_packageable_thing_following_list
   
+  get 'procedure-browser/enabling-legislation/a-z' => 'enabling_legislation_ato_z#index', as: :enabling_legislation_atoz_list
+  get 'procedure-browser/enabling-legislation/a-z/:letter' => 'enabling_legislation_ato_z#show', as: :enabling_legislation_atoz_show
+  
   get 'procedure-browser/enabling-legislation' => 'enabling_legislation#index', as: :enabling_legislation_list
   get 'procedure-browser/enabling-legislation/:enabling_legislation' => 'enabling_legislation#show', as: :enabling_legislation_show
   

--- a/lib/sparql/get/enabling_legislation_atoz.rb
+++ b/lib/sparql/get/enabling_legislation_atoz.rb
@@ -1,0 +1,30 @@
+module Sparql::Get::EnablingLegislationAtoz
+
+  # A method to get an A to Z of enabling legislation.
+  def get_enabling_legislation_atoz
+  
+    # We get the enabling legislation A to Zquery.
+    request_body = enabling_legislation_atoz_query
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the letters.
+    letters = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+    
+      # ... we create a new letter object.
+      letter = Letter.new
+      letter.letter = row['FirstLetter']
+      letter.count = row['Count']
+      
+      # ... and add it to the array of letters.
+      letters << letter
+    end
+  
+    # We return the array of letters.
+    letters
+  end
+end

--- a/lib/sparql/get/enabling_legislation_atoz_letter.rb
+++ b/lib/sparql/get/enabling_legislation_atoz_letter.rb
@@ -1,0 +1,34 @@
+module Sparql::Get::EnablingLegislationAtozLetter
+
+  # A method to get a list of enabling legislation starting with a given letter.
+  def get_enabling_legislation_atoz_letter( letter )
+  
+    # We get the enabling legislation A-Z letter query.
+    request_body = enabling_legislation_atoz_letter_query( letter )
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the enabling legislation.
+    enabling_legislations = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+  
+      # ... we create a new enabling legislation object ...
+      enabling_legislation = EnablingLegislation.new
+      enabling_legislation.identifier = row['EnablingThing']
+      enabling_legislation.label = row['Name']
+      enabling_legislation.date = row['Date'].to_date if row['Date']
+      enabling_legislation.year = row['Year']
+      enabling_legislation.act_number = row['Number']
+      enabling_legislation.uri = row['URL']
+      
+      # ... and add it to the array of enabling legislation.
+      enabling_legislations << enabling_legislation
+    end
+  
+    # We return the array of enabling legislation.
+    enabling_legislations
+  end
+end

--- a/lib/sparql/queries/enabling_legislation_atoz.rb
+++ b/lib/sparql/queries/enabling_legislation_atoz.rb
@@ -1,0 +1,23 @@
+module Sparql::Queries::EnablingLegislationAtoz
+
+  # A SPARQL query to get an A to Z of enabling legislation.
+  def enabling_legislation_atoz_query
+    "
+      PREFIX : <https://id.parliament.uk/schema/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX id: <https://id.parliament.uk/>
+
+      SELECT ?FirstLetter (COUNT(DISTINCT ?EnablingThing) AS ?Count)
+      WHERE {
+        ?EnablingThing a :EnablingThing;
+                       :enabling ?EnabledThing.
+        OPTIONAL { ?EnablingThing :actOfParliamentName ?Name. }
+
+        BIND(UCASE(SUBSTR(STR(?Name), 1, 1)) AS ?FirstLetter)
+      }
+      GROUP BY ?FirstLetter
+      ORDER BY ?FirstLetter
+    "
+  end
+end

--- a/lib/sparql/queries/enabling_legislation_atoz_letter.rb
+++ b/lib/sparql/queries/enabling_legislation_atoz_letter.rb
@@ -1,0 +1,26 @@
+module Sparql::Queries::EnablingLegislationAtozLetter
+
+  # A SPARQL query to get a list of enabling legislation starting with a given letter.
+  def enabling_legislation_atoz_letter_query( letter )
+    "
+      PREFIX : <https://id.parliament.uk/schema/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX id: <https://id.parliament.uk/>
+
+      SELECT DISTINCT ?EnablingThing ?Name ?Number ?Year ?Date ?URL WHERE {
+        ?EnablingThing a :EnablingThing;  
+                       :enabling ?EnabledThing.
+        OPTIONAL { ?EnablingThing :actOfParliamentName ?Name. }
+        OPTIONAL { ?EnablingThing :actOfParliamentNumber ?Number. }
+        OPTIONAL { ?EnablingThing :actOfParliamentYear ?Year. }
+        OPTIONAL { ?EnablingThing :actOfParliamentRoyalAssentDate ?Date. }
+        OPTIONAL { ?EnablingThing :actOfParliamentUrl ?URL. }
+        ?EnabledThing :name ?EnabledThingName.
+
+        FILTER regex(str(?Name), '^#{letter}', 'i')
+      }
+      ORDER BY ?Name
+    "
+  end
+end


### PR DESCRIPTION
- **added active styling for a-z subnav**
- **added routes for listing enabling legislation by a-z**
- **enabling legislation list template now renders intro partial**
- **new partial to render enabling legislation intro which in turn renders a-z subnav**
- **basic letter model to help render enabling legislation a-z**
- **new queries and getters to render an a to z of enabling legislation**
- **enabling legislation controller action list view adapted to include a-z**
- **basic controller and views to render enabling legislation by a-z**
- **full bundle update**
