### PR TITLE
Try switching work package flags to default nil

### DIFF
--- a/app/models/work_package.rb
+++ b/app/models/work_package.rb
@@ -5,8 +5,8 @@
 #  id                               :bigint           not null, primary key
 #  calculation_style_identifier     :text
 #  calculation_style_label          :text
-#  has_committee_concerns           :boolean          default(FALSE)
-#  has_motion_tabled                :boolean          default(FALSE)
+#  has_committee_concerns           :boolean
+#  has_motion_tabled                :boolean
 #  identifier                       :text
 #  made_available_on                :date
 #  making_available_identifier      :text

--- a/db/migrate/20260426144728_switch_work_package_flags_to_default_nil.rb
+++ b/db/migrate/20260426144728_switch_work_package_flags_to_default_nil.rb
@@ -1,0 +1,6 @@
+class SwitchWorkPackageFlagsToDefaultNil < ActiveRecord::Migration[8.1]
+  def change
+    change_column :work_packages, :has_committee_concerns, :boolean, using: "has_committee_concerns::boolean", default: nil
+    change_column :work_packages, :has_motion_tabled, :boolean, using: "has_motion_tabled::boolean", default: nil
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -215,8 +215,8 @@ CREATE TABLE public.work_packages (
     procedure_label text,
     calculation_style_identifier text,
     calculation_style_label text,
-    has_committee_concerns boolean DEFAULT false,
-    has_motion_tabled boolean DEFAULT false,
+    has_committee_concerns boolean,
+    has_motion_tabled boolean,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     search_vector tsvector
@@ -403,6 +403,7 @@ CREATE TRIGGER tsvectorupdate_work_packages BEFORE INSERT OR UPDATE ON public.wo
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260426144728'),
 ('20260424165215'),
 ('20260130135554'),
 ('20260130120901'),


### PR DESCRIPTION
This PR is a database migration, so without amending any code, it removes the default of `false` for the flag columns, instead allowing `nil` - that then means that when you do a CSV download of All of the work packages, those flag columns will now be empty rather than false.