### PR TITLE
add csv to work package list by type

### DIFF
--- a/app/controllers/work_package_primary_legislation_controller.rb
+++ b/app/controllers/work_package_primary_legislation_controller.rb
@@ -5,36 +5,50 @@ class WorkPackagePrimaryLegislationController < ApplicationController
   include Sparql::Queries::PrimaryLegislationWorkPackageCount
   include Sparql::Get::PrimaryLegislationWorkPackages
   include Sparql::Queries::PrimaryLegislationWorkPackages
+  include Sparql::Get::PrimaryLegislationWorkPackagesAll
+  include Sparql::Queries::PrimaryLegislationWorkPackagesAll
   include Sparql::Get::Response
 
   def index
   
-    # We get the page number passed as a parameter.
-    page = params['page']
-    @page = ( page || "1" ).to_i
-    
-    # We get the number of results per page passed as a parameter.
-    results_per_page = params['results-per-page']
-    @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
-    
-    # We get the count of all work packages.
-    @result_count = get_primary_legislation_work_package_count
-    
-    # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
-    if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
-      raise ActionController::RoutingError.new("Not Found")
-    end
-    
-    # We get the set of work packages on this page with this many results per page.
-    @work_packages = get_primary_legislation_work_packages( @page, @results_per_page )
-    
     @page_title = 'Primary legislation work packages'
-    @multiline_page_title = "Work packages <span class='subhead'>Primary legislation</span>".html_safe
-    @description = 'Work packages for primary legislation.'
-    @rss_url = work_package_primary_legislation_list_url( :format => 'rss' )
-    @crumb << { label: 'Work packages', url: work_package_list_url }
-    @crumb << { label: 'Primary legislation', url: nil }
-    @section = 'work-packages'
-    @subsection = 'primary-legislation'
+  
+    respond_to do |format|
+      format.csv {
+        @work_packages = get_primary_legislation_work_packages_all
+        response.headers['Content-Disposition'] = "attachment; filename=\"#{csv_title_from_page_title ( @page_title )}.csv\""
+        render :template => 'work_package/index'
+      }
+      format.any( :html, :rss ) {
+      
+        # We get the page number passed as a parameter.
+        page = params['page']
+        @page = ( page || "1" ).to_i
+    
+        # We get the number of results per page passed as a parameter.
+        results_per_page = params['results-per-page']
+        @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
+    
+        # We get the count of all work packages.
+        @result_count = get_primary_legislation_work_package_count
+    
+        # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
+        if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
+          raise ActionController::RoutingError.new("Not Found")
+        end
+    
+        # We get the set of work packages on this page with this many results per page.
+        @work_packages = get_primary_legislation_work_packages( @page, @results_per_page )
+    
+        @multiline_page_title = "Work packages <span class='subhead'>Primary legislation</span>".html_safe
+        @description = 'Work packages for primary legislation.'
+        @rss_url = work_package_primary_legislation_list_url( :format => 'rss' )
+        @csv_url = work_package_primary_legislation_list_url( :format => 'csv' )
+        @crumb << { label: 'Work packages', url: work_package_list_url }
+        @crumb << { label: 'Primary legislation', url: nil }
+        @section = 'work-packages'
+        @subsection = 'primary-legislation'
+      }
+    end
   end
 end

--- a/app/controllers/work_package_secondary_legislation_controller.rb
+++ b/app/controllers/work_package_secondary_legislation_controller.rb
@@ -5,36 +5,50 @@ class WorkPackageSecondaryLegislationController < ApplicationController
   include Sparql::Queries::SecondaryLegislationWorkPackageCount
   include Sparql::Get::SecondaryLegislationWorkPackages
   include Sparql::Queries::SecondaryLegislationWorkPackages
+  include Sparql::Get::SecondaryLegislationWorkPackagesAll
+  include Sparql::Queries::SecondaryLegislationWorkPackagesAll
   include Sparql::Get::Response
 
   def index
   
-    # We get the page number passed as a parameter.
-    page = params['page']
-    @page = ( page || "1" ).to_i
-    
-    # We get the number of results per page passed as a parameter.
-    results_per_page = params['results-per-page']
-    @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
-    
-    # We get the count of all work packages.
-    @result_count = get_secondary_legislation_work_package_count
-    
-    # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
-    if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
-      raise ActionController::RoutingError.new("Not Found")
-    end
-    
-    # We get the set of work packages on this page with this many results per page.
-    @work_packages = get_secondary_legislation_work_packages( @page, @results_per_page )
-    
     @page_title = 'Secondary legislation work packages'
-    @multiline_page_title = "Work packages <span class='subhead'>Secondary legislation</span>".html_safe
-    @description = 'Work packages for secondary legislation.'
-    @rss_url = work_package_secondary_legislation_list_url( :format => 'rss' )
-    @crumb << { label: 'Work packages', url: work_package_list_url }
-    @crumb << { label: 'Secondary legislation', url: nil }
-    @section = 'work-packages'
-    @subsection = 'secondary-legislation'
+  
+    respond_to do |format|
+      format.csv {
+        @work_packages = get_secondary_legislation_work_packages_all
+        response.headers['Content-Disposition'] = "attachment; filename=\"#{csv_title_from_page_title ( @page_title )}.csv\""
+        render :template => 'work_package/index'
+      }
+      format.any( :html, :rss ) {
+  
+        # We get the page number passed as a parameter.
+        page = params['page']
+        @page = ( page || "1" ).to_i
+    
+        # We get the number of results per page passed as a parameter.
+        results_per_page = params['results-per-page']
+        @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
+    
+        # We get the count of all work packages.
+        @result_count = get_secondary_legislation_work_package_count
+    
+        # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
+        if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
+          raise ActionController::RoutingError.new("Not Found")
+        end
+    
+        # We get the set of work packages on this page with this many results per page.
+        @work_packages = get_secondary_legislation_work_packages( @page, @results_per_page )
+    
+        @multiline_page_title = "Work packages <span class='subhead'>Secondary legislation</span>".html_safe
+        @description = 'Work packages for secondary legislation.'
+        @csv_url = work_package_secondary_legislation_list_url( :format => 'csv' )
+        @rss_url = work_package_secondary_legislation_list_url( :format => 'rss' )
+        @crumb << { label: 'Work packages', url: work_package_list_url }
+        @crumb << { label: 'Secondary legislation', url: nil }
+        @section = 'work-packages'
+        @subsection = 'secondary-legislation'
+      }
+    end
   end
 end

--- a/app/controllers/work_package_treaty_controller.rb
+++ b/app/controllers/work_package_treaty_controller.rb
@@ -5,36 +5,50 @@ class WorkPackageTreatyController < ApplicationController
   include Sparql::Queries::TreatyWorkPackageCount
   include Sparql::Get::TreatyWorkPackages
   include Sparql::Queries::TreatyWorkPackages
+  include Sparql::Get::TreatyWorkPackagesAll
+  include Sparql::Queries::TreatyWorkPackagesAll
   include Sparql::Get::Response
 
   def index
   
-    # We get the page number passed as a parameter.
-    page = params['page']
-    @page = ( page || "1" ).to_i
-    
-    # We get the number of results per page passed as a parameter.
-    results_per_page = params['results-per-page']
-    @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
-    
-    # We get the count of all work packages.
-    @result_count = get_treaty_work_package_count
-    
-    # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
-    if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
-      raise ActionController::RoutingError.new("Not Found")
-    end
-    
-    # We get the set of work packages on this page with this many results per page.
-    @work_packages = get_treaty_work_packages( @page, @results_per_page )
-    
     @page_title = 'Treaty work packages'
-    @multiline_page_title = "Work packages <span class='subhead'>Treaties</span>".html_safe
-    @description = 'Work packages for treaties.'
-    @rss_url = work_package_treaty_list_url( :format => 'rss' )
-    @crumb << { label: 'Work packages', url: work_package_list_url }
-    @crumb << { label: 'Treaties', url: nil }
-    @section = 'work-packages'
-    @subsection = 'treaty'
+  
+    respond_to do |format|
+      format.csv {
+        @work_packages = get_treaty_work_packages_all
+        response.headers['Content-Disposition'] = "attachment; filename=\"#{csv_title_from_page_title ( @page_title )}.csv\""
+        render :template => 'work_package/index'
+      }
+      format.any( :html, :rss ) {
+        
+        # We get the page number passed as a parameter.
+        page = params['page']
+        @page = ( page || "1" ).to_i
+    
+        # We get the number of results per page passed as a parameter.
+        results_per_page = params['results-per-page']
+        @results_per_page = ( results_per_page || $DEFAULT_RESULTS_PER_PAGE ).to_i
+    
+        # We get the count of all work packages.
+        @result_count = get_treaty_work_package_count
+    
+        # If this is not the first page and the number of the first work package on this page exceeds the total number of work packages ...
+        if @page != 1 && ( ( ( @page - 1 ) * @results_per_page ) + 1 > @result_count )
+          raise ActionController::RoutingError.new("Not Found")
+        end
+    
+        # We get the set of work packages on this page with this many results per page.
+        @work_packages = get_treaty_work_packages( @page, @results_per_page )
+    
+        @multiline_page_title = "Work packages <span class='subhead'>Treaties</span>".html_safe
+        @description = 'Work packages for treaties.'
+        @csv_url = work_package_treaty_list_url( :format => 'csv' )
+        @rss_url = work_package_treaty_list_url( :format => 'rss' )
+        @crumb << { label: 'Work packages', url: work_package_list_url }
+        @crumb << { label: 'Treaties', url: nil }
+        @section = 'work-packages'
+        @subsection = 'treaty'
+      }
+    end
   end
 end

--- a/lib/sparql/get/primary_legislation_work_packages_all.rb
+++ b/lib/sparql/get/primary_legislation_work_packages_all.rb
@@ -1,0 +1,48 @@
+module Sparql::Get::PrimaryLegislationWorkPackagesAll
+
+  # A method to get an array of all primary legislation work packages.
+  def get_primary_legislation_work_packages_all
+
+    # We get the primary legislation work packages query passing parameters for the number of results per page and the result offset.
+    request_body = primary_legislation_work_packages_all_query
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the work packages.
+    work_packages = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+  
+      # ... we create a new work package object ...
+      work_package = WorkPackage.new
+      work_package.identifier = row['workPackage']
+      work_package.work_packageable_thing_identifer = row['Paper']
+      work_package.work_packageable_thing_label = row['Papername']
+      work_package.making_available_identifier = row['businessItem']
+      work_package.made_available_on = row['combinedDate'].to_date if row['combinedDate']
+      work_package.procedure_identifier = row['procedure']
+      work_package.procedure_label = row['procedureName']
+      work_package.calculation_style_identifier = row['calculationStyle']
+      work_package.calculation_style_label = row['calculationStyleName']
+      
+      if row['hasCommitteeConcernsFlag'] == 'true'
+        work_package.has_committee_concerns = true
+      else
+        work_package.has_committee_concerns = false
+      end
+      if row['hasMotionTabledFlag'] == 'true'
+        work_package.has_motion_tabled = true
+      else
+        work_package.has_motion_tabled = false
+      end
+      
+      # ... and add it to the array of work packages.
+      work_packages << work_package
+    end
+  
+    # We return the array of work packages.
+    work_packages
+  end
+end

--- a/lib/sparql/get/secondary_legislation_work_packages_all.rb
+++ b/lib/sparql/get/secondary_legislation_work_packages_all.rb
@@ -1,0 +1,48 @@
+module Sparql::Get::SecondaryLegislationWorkPackagesAll
+
+  # A method to get an array of all secondary legislation work packages.
+  def get_secondary_legislation_work_packages_all
+
+    # We get the secondary legislation work packages query.
+    request_body = secondary_legislation_work_packages_all_query
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the work packages.
+    work_packages = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+  
+      # ... we create a new work package object ...
+      work_package = WorkPackage.new
+      work_package.identifier = row['workPackage']
+      work_package.work_packageable_thing_identifer = row['Paper']
+      work_package.work_packageable_thing_label = row['Papername']
+      work_package.making_available_identifier = row['businessItem']
+      work_package.made_available_on = row['combinedDate'].to_date if row['combinedDate']
+      work_package.procedure_identifier = row['procedure']
+      work_package.procedure_label = row['procedureName']
+      work_package.calculation_style_identifier = row['calculationStyle']
+      work_package.calculation_style_label = row['calculationStyleName']
+      
+      if row['hasCommitteeConcernsFlag'] == 'true'
+        work_package.has_committee_concerns = true
+      else
+        work_package.has_committee_concerns = false
+      end
+      if row['hasMotionTabledFlag'] == 'true'
+        work_package.has_motion_tabled = true
+      else
+        work_package.has_motion_tabled = false
+      end
+      
+      # ... and add it to the array of work packages.
+      work_packages << work_package
+    end
+  
+    # We return the array of work packages.
+    work_packages
+  end
+end

--- a/lib/sparql/get/secondary_legislation_work_packages_all.rb
+++ b/lib/sparql/get/secondary_legislation_work_packages_all.rb
@@ -27,16 +27,16 @@ module Sparql::Get::SecondaryLegislationWorkPackagesAll
       work_package.calculation_style_identifier = row['calculationStyle']
       work_package.calculation_style_label = row['calculationStyleName']
       
-      if row['hasCommitteeConcernsFlag'] == 'true'
-        work_package.has_committee_concerns = true
-      else
-        work_package.has_committee_concerns = false
-      end
-      if row['hasMotionTabledFlag'] == 'true'
-        work_package.has_motion_tabled = true
-      else
-        work_package.has_motion_tabled = false
-      end
+      #if row['hasCommitteeConcernsFlag'] == 'true'
+        #work_package.has_committee_concerns = true
+      #else
+        #work_package.has_committee_concerns = false
+      #end
+      #if row['hasMotionTabledFlag'] == 'true'
+        #work_package.has_motion_tabled = true
+      #else
+        #work_package.has_motion_tabled = false
+      #end
       
       # ... and add it to the array of work packages.
       work_packages << work_package

--- a/lib/sparql/get/treaty_work_packages_all.rb
+++ b/lib/sparql/get/treaty_work_packages_all.rb
@@ -1,0 +1,47 @@
+module Sparql::Get::TreatyWorkPackagesAll
+
+  # A method to get an array of all treaty work packages.
+  def get_treaty_work_packages_all
+
+    # We get the treaty work packages query.
+    request_body = treaty_work_packages_all_query
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the work packages.
+    work_packages = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+  
+      # ... we create a new work package object ...
+      work_package = WorkPackage.new
+      work_package.identifier = row['workPackage']
+      work_package.work_packageable_thing_identifer = row['Paper']
+      work_package.work_packageable_thing_label = row['Papername']
+      work_package.making_available_identifier = row['businessItem']
+      work_package.made_available_on = row['combinedDate'].to_date if row['combinedDate']
+      work_package.procedure_identifier = row['procedure']
+      work_package.procedure_label = row['procedureName']
+      work_package.calculation_style_identifier = row['calculationStyle']
+      work_package.calculation_style_label = row['calculationStyleName']
+      if row['hasCommitteeConcernsFlag'] == 'true'
+        work_package.has_committee_concerns = true
+      else
+        work_package.has_committee_concerns = false
+      end
+      if row['hasMotionTabledFlag'] == 'true'
+        work_package.has_motion_tabled = true
+      else
+        work_package.has_motion_tabled = false
+      end
+      
+      # ... and add it to the array of work packages.
+      work_packages << work_package
+    end
+  
+    # We return the array of work packages.
+    work_packages
+  end
+end

--- a/lib/sparql/queries/primary_legislation_work_packages_all.rb
+++ b/lib/sparql/queries/primary_legislation_work_packages_all.rb
@@ -1,0 +1,43 @@
+module Sparql::Queries::PrimaryLegislationWorkPackagesAll
+
+  # A SPARQL query to get all primary legislation work packages.
+  def primary_legislation_work_packages_all_query
+    "
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                    PREFIX : <https://id.parliament.uk/schema/>
+                    PREFIX id: <https://id.parliament.uk/>
+                    SELECT distinct ?Paper ?Papername ?workPackage ?businessItem ?combinedDate ?procedure ?procedure ?procedureName (BOUND(?stepId3) AS ?hasCommitteeConcernsFlag)   
+      (BOUND(?stepId4) AS ?hasMotionTabledFlag)    where {
+
+                   ?Paper a :PublicBillWork .  
+                       ?Paper :name ?Papername ;
+                       :workPackagedThingHasWorkPackage ?workPackage.
+                   optional {   ?workPackage :workPackageHasBusinessItem ?businessItem .
+                     ?businessItem :businessItemHasProcedureStep ?step;
+                            :businessItemDate ?businessItemDate.
+              filter (?step in (id:isWn7s3K, id:cspzmb6w, id:ITNO9JWr, id:otscOTzB))}
+              optional {    ?workPackage :workPackageHasBusinessItem ?businessItem2 .
+                     ?businessItem2 :businessItemHasProcedureStep ?step2;
+                                    :businessItemDate ?businessItemDate2.
+              filter (?step2 in (id:AmYrFxwO))}
+                      ?workPackage :workPackageHasProcedure ?procedure.
+                    ?procedure :name ?procedureName.
+       OPTIONAL {
+       ?workPackage :workPackageHasBusinessItem ?bi3 .
+       ?bi3 :businessItemHasProcedureStep ?stepId3 .
+       ?stepId3 :procedureStepHasProcedureStepCollectionMembership/
+                :procedureStepCollectionMembershipHasProcedureStepCollection id:7CBVQcZF
+     }
+
+       OPTIONAL {
+       ?workPackage :workPackageHasBusinessItem ?bi4 .
+       ?bi4 :businessItemHasProcedureStep ?stepId4 .
+       ?stepId4 :procedureStepHasProcedureStepCollectionMembership/
+                :procedureStepCollectionMembershipHasProcedureStepCollection id:l3g2umNB
+     }
+                       BIND(COALESCE(?businessItemDate, ?businessItemDate2) AS ?combinedDate)
+          } Order by desc(?combinedDate) ?Papername
+    
+    "
+  end
+end

--- a/lib/sparql/queries/secondary_legislation_work_packages_all.rb
+++ b/lib/sparql/queries/secondary_legislation_work_packages_all.rb
@@ -1,0 +1,73 @@
+module Sparql::Queries::SecondaryLegislationWorkPackagesAll
+
+  # A SPARQL query to get all secondary legislation work packages.
+  def secondary_legislation_work_packages_all_query
+    "
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+              PREFIX : <https://id.parliament.uk/schema/>
+              PREFIX id: <https://id.parliament.uk/>
+              SELECT distinct ?Paper ?Papername ?workPackage ?businessItem ?combinedDate ?procedure ?procedure ?procedureName ?calculationStyle ?calculationStyleName   where {
+
+               ?Paper a :EnabledThing .  
+                   ?Paper :name ?Papername ;
+                   :workPackagedThingHasWorkPackage ?workPackage.
+               optional {   ?workPackage :workPackageHasBusinessItem ?businessItem .
+                 ?businessItem :businessItemHasProcedureStep ?step;
+                        :businessItemDate ?businessItemDate.
+          filter (?step in (id:isWn7s3K, id:cspzmb6w, id:ITNO9JWr, id:otscOTzB))}
+          optional {    ?workPackage :workPackageHasBusinessItem ?businessItem2 .
+                 ?businessItem2 :businessItemHasProcedureStep ?step2;
+                                :businessItemDate ?businessItemDate2.
+              filter (?step2 in (id:AmYrFxwO))}
+                  ?workPackage :workPackageHasProcedure ?procedure.
+                ?procedure :name ?procedureName.
+    optional { ?workPackage :workPackageHasCalculationStyle ?calculationStyle. 
+           ?calculationStyle :name ?calculationStyleName. }
+                   BIND(COALESCE(?businessItemDate, ?businessItemDate2) AS ?combinedDate)
+      } Order by desc(?combinedDate) ?Papername
+    "
+  end
+  
+  # A SPARQL query to get all secondary legislation work packages.
+  # Not used because triplestore times out.
+  def secondary_legislation_work_packages_all_query_with_flags
+    "
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+              PREFIX : <https://id.parliament.uk/schema/>
+              PREFIX id: <https://id.parliament.uk/>
+              SELECT distinct ?Paper ?Papername ?workPackage ?businessItem ?combinedDate ?procedure ?procedure ?procedureName ?calculationStyle ?calculationStyleName (BOUND(?stepId3) AS ?hasCommitteeConcernsFlag)   
+  (BOUND(?stepId4) AS ?hasMotionTabledFlag)  where {
+
+              ?Paper a :EnabledThing .  
+                   ?Paper :name ?Papername ;
+                   :workPackagedThingHasWorkPackage ?workPackage.
+               optional {   ?workPackage :workPackageHasBusinessItem ?businessItem .
+                 ?businessItem :businessItemHasProcedureStep ?step;
+                        :businessItemDate ?businessItemDate.
+          filter (?step in (id:isWn7s3K, id:cspzmb6w, id:ITNO9JWr, id:otscOTzB))}
+          optional {    ?workPackage :workPackageHasBusinessItem ?businessItem2 .
+                 ?businessItem2 :businessItemHasProcedureStep ?step2;
+                                :businessItemDate ?businessItemDate2.
+              filter (?step2 in (id:AmYrFxwO))}
+                  ?workPackage :workPackageHasProcedure ?procedure.
+                ?procedure :name ?procedureName.
+    optional { ?workPackage :workPackageHasCalculationStyle ?calculationStyle. 
+           ?calculationStyle :name ?calculationStyleName. }
+     OPTIONAL {
+     ?workPackage :workPackageHasBusinessItem ?bi3 .
+     ?bi3 :businessItemHasProcedureStep ?stepId3 .
+     ?stepId3 :procedureStepHasProcedureStepCollectionMembership/
+             :procedureStepCollectionMembershipHasProcedureStepCollection id:7CBVQcZF
+   }
+   
+     OPTIONAL {
+     ?workPackage :workPackageHasBusinessItem ?bi4 .
+     ?bi4 :businessItemHasProcedureStep ?stepId4 .
+     ?stepId4 :procedureStepHasProcedureStepCollectionMembership/
+              :procedureStepCollectionMembershipHasProcedureStepCollection id:l3g2umNB
+   }
+                   BIND(COALESCE(?businessItemDate, ?businessItemDate2) AS ?combinedDate)
+      } Order by desc(?combinedDate) ?Papername
+    "
+  end
+end

--- a/lib/sparql/queries/treaty_work_packages_all.rb
+++ b/lib/sparql/queries/treaty_work_packages_all.rb
@@ -1,0 +1,44 @@
+module Sparql::Queries::TreatyWorkPackagesAll
+
+  # A SPARQL query to get all treaty work packages.
+  def treaty_work_packages_all_query
+    "
+      PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                  PREFIX : <https://id.parliament.uk/schema/>
+                  PREFIX id: <https://id.parliament.uk/>
+                  SELECT distinct ?Paper ?Papername ?workPackage ?businessItem ?combinedDate ?procedure ?procedure ?procedureName ?calculationStyle ?calculationStyleName (BOUND(?stepId3) AS ?hasCommitteeConcernsFlag)   
+      (BOUND(?stepId4) AS ?hasMotionTabledFlag)  where {
+
+                   ?Paper a :Treaty.  
+                       ?Paper :name ?Papername ;
+                       :workPackagedThingHasWorkPackage ?workPackage.
+                   optional {   ?workPackage :workPackageHasBusinessItem ?businessItem .
+                     ?businessItem :businessItemHasProcedureStep ?step;
+                            :businessItemDate ?businessItemDate.
+              filter (?step in (id:isWn7s3K, id:cspzmb6w, id:ITNO9JWr, id:otscOTzB))}
+              optional {    ?workPackage :workPackageHasBusinessItem ?businessItem2 .
+                     ?businessItem2 :businessItemHasProcedureStep ?step2;
+                                    :businessItemDate ?businessItemDate2.
+              filter (?step2 in (id:AmYrFxwO))}
+                      ?workPackage :workPackageHasProcedure ?procedure.
+                    ?procedure :name ?procedureName.
+                   optional { ?workPackage :workPackageHasCalculationStyle ?calculationStyle. 
+                      ?calculationStyle :name ?calculationStyleName. }
+        OPTIONAL {
+         ?workPackage :workPackageHasBusinessItem ?bi3 .
+         ?bi3 :businessItemHasProcedureStep ?stepId3 .
+         ?stepId3 :procedureStepHasProcedureStepCollectionMembership/
+                  :procedureStepCollectionMembershipHasProcedureStepCollection id:7CBVQcZF
+       }
+
+         OPTIONAL {
+         ?workPackage :workPackageHasBusinessItem ?bi4 .
+         ?bi4 :businessItemHasProcedureStep ?stepId4 .
+         ?stepId4 :procedureStepHasProcedureStepCollectionMembership/
+                  :procedureStepCollectionMembershipHasProcedureStepCollection id:l3g2umNB
+       }
+          BIND(COALESCE(?businessItemDate, ?businessItemDate2) AS ?combinedDate)
+          } Order by desc(?combinedDate) ?Papername
+    "
+  end
+end


### PR DESCRIPTION
- **added csv view for primary legislation work packages**
- **added csv view for secondary legislation work packages**
- **added csv view for treaty work packages**
- **commented out lines dealing with getting committee and motions flags from the all secondary legislation work package getter, because the query does not yet return them and we don't want the csv to show false**
