### PR TITLE
add current enabling legislation

### DIFF
--- a/app/controllers/enabling_legislation_controller.rb
+++ b/app/controllers/enabling_legislation_controller.rb
@@ -51,7 +51,7 @@ class EnablingLegislationController < ApplicationController
       format.html {
       
         # We get the enabling legislation a to z.
-        #@letters = get_enabling_legislation_atoz
+        @letters = get_enabling_legislation_atoz
         
         @page_title = 'Legislation enabling instruments currently before Parliament'
         @multiline_page_title = "Enabling legislation <span class='subhead'>Legislation enabling instruments currently before Parliament</span>".html_safe
@@ -60,7 +60,7 @@ class EnablingLegislationController < ApplicationController
         @crumb << { label: 'Enabling legislation', url: enabling_legislation_list_url }
         @crumb << { label: 'Current', url: nil }
         @section = 'enabling-legislation'
-        @subsection = 'all'
+        @subsection = 'current'
       }
     end
   end

--- a/app/controllers/enabling_legislation_controller.rb
+++ b/app/controllers/enabling_legislation_controller.rb
@@ -5,6 +5,8 @@ class EnablingLegislationController < ApplicationController
   include Sparql::Queries::EnablingLegislationAtoz
   include Sparql::Get::EnablingLegislations
   include Sparql::Queries::EnablingLegislations
+  include Sparql::Get::EnablingLegislationsCurrent
+  include Sparql::Queries::EnablingLegislationsCurrent
   include Sparql::Get::EnablingLegislation
   include Sparql::Queries::EnablingLegislation
   include Sparql::Get::EnablingLegislationWorkPackageCountCurrent
@@ -30,6 +32,33 @@ class EnablingLegislationController < ApplicationController
         @description = 'Legislation delegating powers, enabling one or more instruments subject to parliamentary procedure.'
         @csv_url = enabling_legislation_list_url( :format => 'csv' )
         @crumb << { label: 'Enabling legislation', url: nil }
+        @section = 'enabling-legislation'
+        @subsection = 'all'
+      }
+    end
+  end
+  
+  def current
+    
+    # We get the current enabling legislation items ...
+    # ... being items of legislation enabling instruments currently before Parliament.
+    @enabling_legislations = get_enabling_legislations_current
+    
+    respond_to do |format|
+      format.csv {
+      render :template => 'enabling_legislation/index'
+      }
+      format.html {
+      
+        # We get the enabling legislation a to z.
+        #@letters = get_enabling_legislation_atoz
+        
+        @page_title = 'Legislation enabling instruments currently before Parliament'
+        @multiline_page_title = "Enabling legislation <span class='subhead'>Legislation enabling instruments currently before Parliament</span>".html_safe
+        @description = 'Legislation enabling instruments currently before Parliament.'
+        @csv_url = enabling_legislation_current_url( :format => 'csv' )
+        @crumb << { label: 'Enabling legislation', url: enabling_legislation_list_url }
+        @crumb << { label: 'Current', url: nil }
         @section = 'enabling-legislation'
         @subsection = 'all'
       }

--- a/app/views/enabling_legislation/_current_list_intro.html.erb
+++ b/app/views/enabling_legislation/_current_list_intro.html.erb
@@ -1,0 +1,3 @@
+<div class="reading-width mb-3">
+	<%= content_tag( 'p', 'Legislation delegating powers, enabling one or more instruments currently before Parliament.' ) %>
+</div>

--- a/app/views/enabling_legislation/_current_list_intro.html.erb
+++ b/app/views/enabling_legislation/_current_list_intro.html.erb
@@ -1,3 +1,5 @@
-<div class="reading-width mb-3">
+<div class="reading-width">
 	<%= content_tag( 'p', 'Legislation delegating powers, enabling one or more instruments currently before Parliament.' ) %>
 </div>
+
+<%= render :partial => 'enabling_legislation_ato_z/nav', :object => @letters %>

--- a/app/views/enabling_legislation/current.html.erb
+++ b/app/views/enabling_legislation/current.html.erb
@@ -1,0 +1,14 @@
+<%= render 'layouts/search/form', path: enabling_legislation_list_search_path %>
+
+<%= render :partial => 'current_list_intro' %>
+
+<div class="reading-width">
+
+	<%= list_item_count_sentence( 'enabling legislation item', @enabling_legislations.size ) %>
+	
+	<%= render :partial => 'library_design/feeds/feeds' %>
+
+	<ol class="unnumbered">
+		<%= render :partial => 'enabling_legislation', :collection => @enabling_legislations %>
+	</ol>
+</div>

--- a/app/views/enabling_legislation_ato_z/_nav.html.erb
+++ b/app/views/enabling_legislation_ato_z/_nav.html.erb
@@ -1,4 +1,5 @@
 <%= render 'library_design/subnav/subnav' do %>
 	<%= render :partial => 'enabling_legislation_ato_z/letter', :collection => nav %>
 	<%= link_to( 'All', enabling_legislation_list_url, :class => 'all' ) %>
+	<%= link_to( 'Legislation enabling instruments currently before Parliament', enabling_legislation_current_url, :class => 'current' ) %>
 <% end %>

--- a/app/views/enabling_legislation_ato_z/_nav.html.erb
+++ b/app/views/enabling_legislation_ato_z/_nav.html.erb
@@ -1,5 +1,5 @@
 <%= render 'library_design/subnav/subnav' do %>
 	<%= render :partial => 'enabling_legislation_ato_z/letter', :collection => nav %>
 	<%= link_to( 'All', enabling_legislation_list_url, :class => 'all' ) %>
-	<%= link_to( 'Legislation enabling instruments currently before Parliament', enabling_legislation_current_url, :class => 'current' ) %>
+	<%= link_to( 'Current', enabling_legislation_current_url, :class => 'current' ) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   get 'procedure-browser/enabling-legislation/lookup' => 'enabling_legislation_lookup#index', as: :enabling_legislation_lookup_list
   
   get 'procedure-browser/enabling-legislation' => 'enabling_legislation#index', as: :enabling_legislation_list
+  get 'procedure-browser/enabling-legislation/current' => 'enabling_legislation#current', as: :enabling_legislation_current
   get 'procedure-browser/enabling-legislation/search' => 'enabling_legislation#index_search', as: :enabling_legislation_list_search
 
   get 'procedure-browser/enabling-legislation/:enabling_legislation' => 'enabling_legislation#show', as: :enabling_legislation_show

--- a/lib/sparql/get/enabling_legislation_atoz.rb
+++ b/lib/sparql/get/enabling_legislation_atoz.rb
@@ -18,7 +18,6 @@ module Sparql::Get::EnablingLegislationAtoz
       # ... we create a new letter object.
       letter = Letter.new
       letter.letter = row['FirstLetter']
-      letter.count = row['Count']
       
       # ... and add it to the array of letters.
       letters << letter

--- a/lib/sparql/get/enabling_legislations_current.rb
+++ b/lib/sparql/get/enabling_legislations_current.rb
@@ -1,0 +1,34 @@
+module Sparql::Get::EnablingLegislationsCurrent
+
+  # A method to get an array of all legislation enabling an instrument currently before Parliament.
+  def get_enabling_legislations_current
+
+    # We get the all enabling legislation current query.
+    request_body = enabling_legislations_current_query
+  
+    # We get the SPARQL response as a CSV.
+    csv = get_sparql_response_as_csv( request_body )
+  
+    # We construct an array to hold the enabling legislation.
+    enabling_legislations = []
+  
+    # For each row in the CSV ...
+    csv.each do |row|
+  
+      # ... we create a new enabling legislation object ...
+      enabling_legislation = EnablingLegislation.new
+      enabling_legislation.identifier = row['enablingThing']
+      enabling_legislation.label = row['name']
+      enabling_legislation.date = row['date'].to_date if row['date']
+      enabling_legislation.year = row['year']
+      enabling_legislation.act_number = row['number']
+      enabling_legislation.uri = row['URL']
+      
+      # ... and add it to the array of enabling legislation.
+      enabling_legislations << enabling_legislation
+    end
+  
+    # We return the array of enabling legislation.
+    enabling_legislations
+  end
+end

--- a/lib/sparql/queries/enabling_legislation_atoz.rb
+++ b/lib/sparql/queries/enabling_legislation_atoz.rb
@@ -8,7 +8,7 @@ module Sparql::Queries::EnablingLegislationAtoz
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
       PREFIX id: <https://id.parliament.uk/>
 
-      SELECT ?FirstLetter (COUNT(DISTINCT ?EnablingThing) AS ?Count)
+      SELECT ?FirstLetter
       WHERE {
         ?EnablingThing a :EnablingThing;
                        :enabling ?EnabledThing.

--- a/lib/sparql/queries/enabling_legislations_current.rb
+++ b/lib/sparql/queries/enabling_legislations_current.rb
@@ -1,0 +1,50 @@
+module Sparql::Queries::EnablingLegislationsCurrent
+
+  # A SPARQL query to get all legislation enabling an instrument currently before Parliament.
+  def enabling_legislations_current_query
+    [
+    
+      # The title of the SPARQL query.
+      'A list of legislation enabling instruments currently before Parliament',
+      
+      # The link to the SPARQL query.
+      '',
+      
+      # The SPARQL query.
+      "
+        # We declare the Parliament and ID namespaces.
+        PREFIX : <https://id.parliament.uk/schema/>
+        PREFIX id: <https://id.parliament.uk/>
+
+        # We select the relevant properties we want to appear in results.
+        SELECT DISTINCT ?enablingThing ?name ?number ?year ?date ?URL WHERE {
+  
+        # We find all enabling things that enable one or more things currently before Parliament.
+        ?enablingThing a :EnablingThing;  
+        :enabling ?enabledThing.
+
+        # We look for the names of those enabling things.
+        ?enablingThing :actOfParliamentName ?name.
+
+        # We specify that an enabling thing might have a name, number, year, date and url but is not required to have any of those properties. 
+        OPTIONAL { ?enablingThing :actOfParliamentNumber ?number. }
+        OPTIONAL { ?enablingThing :actOfParliamentYear ?year. }
+        OPTIONAL { ?enablingThing :actOfParliamentRoyalAssentDate ?date. }
+        OPTIONAL { ?enablingThing :actOfParliamentUrl ?url. }
+
+        # We look for enabled things that have a work package.  
+        ?enabledThing :workPackagedThingHasWorkPackage ?workPackage.
+
+        # We specify that the work package should not have a business item that actualises a step in the 'End steps' step collection. This means only work packages that have not been concluded will appear in the results. 
+        MINUS { ?workPackage :workPackageHasBusinessItem ?bi2.
+        ?bi2 :businessItemHasProcedureStep ?stepId2.
+        # We specify the id for the 'End steps' step collection.    
+        ?stepId2 :procedureStepHasProcedureStepCollectionMembership/:procedureStepCollectionMembershipHasProcedureStepCollection id:TRohjSuI} 
+        }
+
+        # We order the results by name.  
+        ORDER BY ?name
+      "
+    ]
+  end
+end


### PR DESCRIPTION
- **added route to list legislation enabling one or more instruments currently before parliament**
- **added controller action to list legislation enabling one or more instruments currently before parliament**
- **added template to list legislation enabling one or more instruments currently before parliament**
- **added new intro partial for template listing legislation enabling instruments currently before parliament**
- **added new query and getter for  legislation enabling instruments currently before parliament**
- **added current to enabling legislation a-z nav**
- **current enabling legislation intro now includes a-z nav**
- **current enabling legislation now includes call to get a-z letters and sets proper sub nav highlight**
- **changed wording of current in anabling leg a-z nav**
- **removed count from enabling legislation a-z query and getter**
