### PR TITLE
add message to lookup when instrument not found

### DIFF
--- a/app/controllers/work_packageable_thing_lookup_controller.rb
+++ b/app/controllers/work_packageable_thing_lookup_controller.rb
@@ -23,9 +23,9 @@ class WorkPackageableThingLookupController < ApplicationController
     else
     
       # ... we set the not found page meta information ...
-      @page_title = 'Work packageable thing not found'
-      @multiline_page_title = "Work packageable thing <span class='subhead'>Not found</span>".html_safe
-      @description = 'We were unable to find that work packageable thing.'
+      @page_title = 'Instrument not found'
+      @multiline_page_title = "Instrument <span class='subhead'>Not found</span>".html_safe
+      @description = 'We were unable to find that instrument.'
       @crumb << { label: 'Work packageable things', url: work_packageable_thing_list_url }
       @crumb << { label: 'Not found', url: nil }
       @section = 'work-packages'

--- a/app/views/enabling_legislation/_intro.html.erb
+++ b/app/views/enabling_legislation/_intro.html.erb
@@ -1,5 +1,7 @@
 <%= enabling_legislation_description_with_markup( intro ) %>
 
+<%= content_tag( 'p', 'Instruments listed here are those laid since the start of the 2017-19 session, subject to parliamentary procedure.', :class => 'reading-width' ) %>
+
 <% if intro.uri -%>
 	<div class="reading-width highlight highlight-info">
 		<%= content_tag( 'p', "#{link_to( 'Read the enabling legislation', intro.uri )} at legislation.gov.uk.".html_safe ) %>

--- a/app/views/enabling_legislation/_intro.html.erb
+++ b/app/views/enabling_legislation/_intro.html.erb
@@ -1,7 +1,5 @@
 <%= enabling_legislation_description_with_markup( intro ) %>
 
-<%= content_tag( 'p', 'Instruments listed here are those laid since the start of the 2017-19 session, subject to parliamentary procedure.', :class => 'reading-width' ) %>
-
 <% if intro.uri -%>
 	<div class="reading-width highlight highlight-info">
 		<%= content_tag( 'p', "#{link_to( 'Read the enabling legislation', intro.uri )} at legislation.gov.uk.".html_safe ) %>

--- a/app/views/enabling_legislation_work_package/index.html.erb
+++ b/app/views/enabling_legislation_work_package/index.html.erb
@@ -2,8 +2,10 @@
 
 <div class="reading-width">
 
-	<%= list_item_count_sentence( 'work package', @result_count ) %>
+	<%= content_tag( 'p', 'Instruments listed here are those laid since the start of the 2017-19 session, subject to parliamentary procedure.' ) %>
 
+	<%= list_item_count_sentence( 'work package', @result_count ) %>
+	
 	<%= render :partial => 'library_design/feeds/feeds' %>
 
 	<% unless @work_packages.empty? -%>

--- a/app/views/enabling_legislation_work_packageable_thing/index.html.erb
+++ b/app/views/enabling_legislation_work_packageable_thing/index.html.erb
@@ -1,6 +1,9 @@
 <%= render :partial => 'enabling_legislation/intro', :object => @enabling_legislation %>
 
 <div class="reading-width">
+
+	<%= content_tag( 'p', 'Instruments listed here are those laid since the start of the 2017-19 session, subject to parliamentary procedure.' ) %>
+	
 	<%= list_item_count_sentence( 'work packageable thing', @result_count ) %>
 
 	<% unless @enabling_legislation_work_packageable_things.empty? -%>

--- a/app/views/work_packageable_thing_lookup/not_found.html.erb
+++ b/app/views/work_packageable_thing_lookup/not_found.html.erb
@@ -1,1 +1,8 @@
-<%= content_tag( 'p', 'Sorry, we were unable to find a work packageable thing from the information which was provided.' ) %>
+<%= content_tag( 'p', 'Sorry, we were unable to find an instrument from the information provided. This may be because:' ) %>
+<ul>
+	<%= content_tag( 'li', 'the instrument was never laid before Parliament' ) %>
+	<%= content_tag( 'li', 'the instrument was laid before Parliament but was not subject to procedure' ) %>
+	<%= content_tag( 'li', 'the instrument was laid before Parliament prior to the 2017-19 session' ) %>
+	<%= content_tag( 'li', 'the instrument was laid before Parliament in draft, was later made, and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the made instrument and that of the earlier draft instrument' ) %>
+	<%= content_tag( 'li', 'the instrument was laid before Parliament as a class ii made affirmative, gained a new URL once approved by Parliament,  and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the approved instrument and that of the instrument as laid' ) %>
+</ul>

--- a/app/views/work_packageable_thing_lookup/not_found.html.erb
+++ b/app/views/work_packageable_thing_lookup/not_found.html.erb
@@ -1,8 +1,8 @@
-<%= content_tag( 'p', 'Sorry, we were unable to find an instrument from the information provided. This may be because:' ) %>
+<%= content_tag( 'p', 'Sorry, we were unable to find an instrument from the information provided. This may be because the instrument:' ) %>
 <ul>
-	<%= content_tag( 'li', 'the instrument was never laid before Parliament' ) %>
-	<%= content_tag( 'li', 'the instrument was laid before Parliament but was not subject to procedure' ) %>
-	<%= content_tag( 'li', 'the instrument was laid before Parliament prior to the 2017-19 session' ) %>
-	<%= content_tag( 'li', 'the instrument was laid before Parliament in draft, was later made, and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the made instrument and that of the earlier draft instrument' ) %>
-	<%= content_tag( 'li', 'the instrument was laid before Parliament as a class ii made affirmative, gained a new URL once approved by Parliament,  and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the approved instrument and that of the instrument as laid' ) %>
+	<%= content_tag( 'li', 'was never laid before Parliament' ) %>
+	<%= content_tag( 'li', 'was laid before Parliament but was not subject to procedure' ) %>
+	<%= content_tag( 'li', 'was laid before Parliament prior to the 2017-19 session' ) %>
+	<%= content_tag( 'li', 'was laid before Parliament in draft, made at a later date, and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the made instrument and that of the earlier draft instrument' ) %>
+	<%= content_tag( 'li', 'was laid before Parliament as a class ii made affirmative, gained a new URL once approved by Parliament,  and legislation.gov.uk has yet to publish a supersedes relationship between the URL of the approved instrument and that of the instrument as laid' ) %>
 </ul>


### PR DESCRIPTION
- **added explainer as to why an instrument might be not be found from the lookup**
- **changed meta information for instrument not found lookup**
- **added text to enabling legislation partial explaining that instruments listed are from 2017**
- **jayne edits**
- **moved the since 2017 caveat off global enabling leg listings into specific templates**
